### PR TITLE
Clippy: remove uneeded format!() in panic!()

### DIFF
--- a/src/capi.rs
+++ b/src/capi.rs
@@ -72,7 +72,7 @@ extern "C" fn __ts_add_region(
     let name = unsafe { CStr::from_ptr(name).to_str().unwrap() };
     match space.add_region(name, region.deref()) {
         Ok(r) => to_c_ptr(r),
-        Err(e) => panic!(format!("{:?}", e)),
+        Err(e) => panic!("{:?}", e),
     }
 }
 
@@ -91,7 +91,7 @@ extern "C" fn __ts_get_region(space: &Space, name: *const c_char) -> *const Box<
     if let Some(r) = space.get_region(name) {
         to_c_ptr(r)
     } else {
-        panic!(format!("no region {}", name))
+        panic!("no region {}", name)
     }
 }
 
@@ -120,7 +120,7 @@ extern "C" fn __ts_alloc_region(
         }
     } {
         Ok(region) => to_c_ptr(region),
-        Err(msg) => panic!(msg),
+        Err(msg) => panic!("{}", msg),
     }
 }
 

--- a/src/memory/allocator/mod.rs
+++ b/src/memory/allocator/mod.rs
@@ -117,7 +117,7 @@ impl Allocator {
             self.free_blocks = List::cons(post_info, &self.free_blocks);
             self.alloced_blocks = alloced_blocks;
         } else {
-            panic!(format!("invalid free @{}", addr));
+            panic!("invalid free @{}", addr);
         }
     }
 }

--- a/src/memory/region/mod.rs
+++ b/src/memory/region/mod.rs
@@ -41,7 +41,7 @@ pub trait U16Access: BytesAccess {
     fn write(&self, addr: &u64, data: u16) {
         assert!(
             addr.trailing_zeros() > 0,
-            format!("U16Access:unaligned addr:{:#x}", *addr)
+            "U16Access:unaligned addr:{:#x}", *addr
         );
         BytesAccess::write(self, addr, &data.to_le_bytes()).unwrap();
     }
@@ -49,7 +49,7 @@ pub trait U16Access: BytesAccess {
     fn read(&self, addr: &u64) -> u16 {
         assert!(
             addr.trailing_zeros() > 0,
-            format!("U16Access:unaligned addr:{:#x}", *addr)
+            "U16Access:unaligned addr:{:#x}", *addr
         );
         let mut bytes = [0 as u8; size_of::<u16>()];
         BytesAccess::read(self, addr, &mut bytes).unwrap();
@@ -61,7 +61,7 @@ pub trait U32Access: BytesAccess {
     fn write(&self, addr: &u64, data: u32) {
         assert!(
             addr.trailing_zeros() > 1,
-            format!("U32Access:unaligned addr:{:#x}", *addr)
+            "U32Access:unaligned addr:{:#x}", *addr
         );
         BytesAccess::write(self, addr, &data.to_le_bytes()).unwrap();
     }
@@ -69,7 +69,7 @@ pub trait U32Access: BytesAccess {
     fn read(&self, addr: &u64) -> u32 {
         assert!(
             addr.trailing_zeros() > 1,
-            format!("U32Access:unaligned addr:{:#x}", *addr)
+            "U32Access:unaligned addr:{:#x}", *addr
         );
         let mut bytes = [0 as u8; size_of::<u32>()];
         BytesAccess::read(self, addr, &mut bytes).unwrap();
@@ -81,7 +81,7 @@ pub trait U64Access: BytesAccess {
     fn write(&self, addr: &u64, data: u64) {
         assert!(
             addr.trailing_zeros() > 2,
-            format!("U64Access:unaligned addr:{:#x}", *addr)
+            "U64Access:unaligned addr:{:#x}", *addr
         );
         BytesAccess::write(self, addr, &data.to_le_bytes()).unwrap();
     }
@@ -89,7 +89,7 @@ pub trait U64Access: BytesAccess {
     fn read(&self, addr: &u64) -> u64 {
         assert!(
             addr.trailing_zeros() > 2,
-            format!("U64Access:unaligned addr:{:#x}", *addr)
+            "U64Access:unaligned addr:{:#x}", *addr
         );
         let mut bytes = [0 as u8; size_of::<u64>()];
         BytesAccess::read(self, addr, &mut bytes).unwrap();
@@ -420,12 +420,10 @@ impl Region {
                 && *va < self.info.base + self.info.size
                 && *va + size as u64 - 1 >= self.info.base
                 && *va + size as u64 - 1 < self.info.base + self.info.size,
-            format!(
                 "addr {:#x}-{:#x} translate fail!range {:#x?}",
                 *va,
                 *va + size as u64 - 1,
                 self.info
-            )
         );
         match &self.memory {
             Memory::Remap(remap) => Some(va - self.info.base + remap.info.base),


### PR DESCRIPTION
I tested this and the vault fixes, and Linux ran just fine.